### PR TITLE
Fix Dockerfile and test in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+services:
+  - docker
+
+before_install:  
+  - sudo apt-get update
+  - sudo DEBIAN_FRONTEND=noninteractive apt-get -q -o Dpkg::Options::="--force-confnew" install -y docker-engine
+
+script:
+    - docker build -t test .

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM jupyter/notebook:latest
 
 RUN mkdir /omero-install
 WORKDIR /omero-install
-RUN git clone git://github.com/ome/omero-install .
+RUN git clone -b v5.2.5 --depth=1 git://github.com/ome/omero-install .
 WORKDIR /omero-install/linux
 RUN \
 	bash -eux step01_ubuntu1404_init.sh && \


### PR DESCRIPTION
@manics pointed out in gh-1 that use of omero-install@master in the Dockerfile could lead to unintended consequences. This moves to using the v5.2.5 tag. Use of a "latest"-style zip might be preferable in the longer-term.
