### PR TITLE
[Do not merge] hacks to run cytoscape headless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,16 @@ RUN chown -R omero:omero /home/omero/.local /notebooks
 
 RUN echo /notebooks/library > /usr/local/lib/python2.7/dist-packages/idr-notebooks.pth
 
+# Dodgy hacks to get cytoscape running headless
+RUN apt-get install -y xvfb screen
+
 USER omero
+WORKDIR /home/omero
+# WARNING: https isn't supported
+RUN wget -q http://chianti.ucsd.edu/cytoscape-3.4.0/Cytoscape_3_4_0_unix.sh && \
+    sh Cytoscape_3_4_0_unix.sh -q
+ADD cytoscape_headless.sh /home/omero/cytoscape_headless.sh
+
 # Add a notebook profile.
 WORKDIR /notebooks
 RUN mkdir -p -m 700 /home/omero/.jupyter/ && \

--- a/cytoscape_headless.sh
+++ b/cytoscape_headless.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+Xvfb :0 -screen 0 1024x768x24&
+sleep 5
+export DISPLAY=:0
+screen -S cytoscape -d -m /home/omero/Cytoscape_v3.4.0/cytoscape.sh


### PR DESCRIPTION
An example of how you can force cytoscape to run in the background so you can connect to it remotely using its REST API.

In the Ipython notebook add a cell to start cytoscape in the background:

```
import subprocess
subprocess.Popen(['sh', '/home/omero/cytoscape_headless.sh'])
```

Note this won't return any output if it fails. If you run it more than once in the same docker session it'll probably fail too.
