### PR TITLE
Add /scratch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,10 @@ USER root
 RUN apt-get update -y && \
     apt-get install -y nodejs
 
-RUN install -o jovyan -g users -d /notebooks /opt/omero
+RUN install -o jovyan -g users -d \
+    /notebooks \
+    /opt/omero \
+    /scratch
 
 USER jovyan
 


### PR DESCRIPTION
Adds a scratch dir independent of the mounted notebooks

In future this could be mounted as a persistent volume separate from the notebooks.