### PR TITLE
Add missing dependencies for the gene ontology query notebooks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,11 @@ RUN conda install --name python2 --quiet --yes \
 RUN conda install --name python2 --quiet --yes -c bioconda zeroc-ice && \
     conda install --name python2 --quiet --yes -c damianavila82 rise && \
     conda install --name python2 --quiet --yes -c pdrops pygraphviz -y && \
-    /opt/conda/envs/python2/bin/pip install py2cytoscape pydot graphviz tqdm gseapy
+    /opt/conda/envs/python2/bin/pip install py2cytoscape 
+    /opt/conda/envs/python2/bin/pip install pydot 
+    /opt/conda/envs/python2/bin/pip graphviz 
+    /opt/conda/envs/python2/bin/pip tqdm 
+    /opt/conda/envs/python2/bin/pip gseapy
 
 # Add idr-notebook library to path
 RUN echo /notebooks/library > /opt/conda/envs/python2/lib/python2.7/site-packages/idr-notebooks.pth

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,8 @@ RUN conda install --name python2 --quiet --yes \
 # https://github.com/damianavila/RISE
 RUN conda install --name python2 --quiet --yes -c bioconda zeroc-ice && \
     conda install --name python2 --quiet --yes -c damianavila82 rise && \
-    pip2 install py2cytoscape
+    conda install --name python2 --quiet --yes -c pdrops pygraphviz -y && \
+    pip2 install py2cytoscape pydot graphviz tqdm gseapy
 
 # Add idr-notebook library to path
 RUN echo /notebooks/library > /opt/conda/envs/python2/lib/python2.7/site-packages/idr-notebooks.pth

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,18 +21,19 @@ RUN conda install --name python2 --quiet --yes \
     joblib \
     markdown \
     pytables \
-    python-igraph 
+    python-igraph
 
 # RISE: "Live" Reveal.js Jupyter/IPython Slideshow Extension
 # https://github.com/damianavila/RISE
 RUN conda install --name python2 --quiet --yes -c bioconda zeroc-ice && \
     conda install --name python2 --quiet --yes -c damianavila82 rise && \
-    conda install --name python2 --quiet --yes -c pdrops pygraphviz -y && \
-    /opt/conda/envs/python2/bin/pip install py2cytoscape 
-    /opt/conda/envs/python2/bin/pip install pydot 
-    /opt/conda/envs/python2/bin/pip graphviz 
-    /opt/conda/envs/python2/bin/pip tqdm 
-    /opt/conda/envs/python2/bin/pip gseapy
+    conda install --name python2 --quiet --yes -c pdrops pygraphviz && \
+    /opt/conda/envs/python2/bin/pip install \
+        graphviz \
+        gseapy \
+        py2cytoscape \
+        pydot \
+        tqdm
 
 # Add idr-notebook library to path
 RUN echo /notebooks/library > /opt/conda/envs/python2/lib/python2.7/site-packages/idr-notebooks.pth

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN install -o jovyan -g users -d /notebooks /opt/omero
 
 USER jovyan
 
-RUN pip2 install omego && \
+RUN /opt/conda/bin/pip2 install omego && \
     cd /opt/omero && \
     /opt/conda/envs/python2/bin/omego download --ice 3.6 server --release 5.3 --sym OMERO.server && \
     rm -f OMERO.server-*.zip && \
@@ -27,7 +27,7 @@ RUN conda install --name python2 --quiet --yes \
 RUN conda install --name python2 --quiet --yes -c bioconda zeroc-ice && \
     conda install --name python2 --quiet --yes -c damianavila82 rise && \
     conda install --name python2 --quiet --yes -c pdrops pygraphviz -y && \
-    pip2 install py2cytoscape pydot graphviz tqdm gseapy
+    /opt/conda/bin/pip2 install py2cytoscape pydot graphviz tqdm gseapy
 
 # Add idr-notebook library to path
 RUN echo /notebooks/library > /opt/conda/envs/python2/lib/python2.7/site-packages/idr-notebooks.pth

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/scipy-notebook:latest
+FROM jupyter/scipy-notebook@sha256:4825556416ec7dcf4df73585a71595d29a274ef7d6d7c97267606661f3466952
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN install -o jovyan -g users -d /notebooks /opt/omero
 
 USER jovyan
 
-RUN /opt/conda/bin/pip2 install omego && \
+RUN conda create -n python2 python=2 --quiet --yes
+RUN /opt/conda/envs/python2/bin/pip install omego && \
     cd /opt/omero && \
     /opt/conda/envs/python2/bin/omego download --ice 3.6 server --release 5.3 --sym OMERO.server && \
     rm -f OMERO.server-*.zip && \
@@ -20,14 +21,14 @@ RUN conda install --name python2 --quiet --yes \
     joblib \
     markdown \
     pytables \
-    python-igraph
+    python-igraph 
 
 # RISE: "Live" Reveal.js Jupyter/IPython Slideshow Extension
 # https://github.com/damianavila/RISE
 RUN conda install --name python2 --quiet --yes -c bioconda zeroc-ice && \
     conda install --name python2 --quiet --yes -c damianavila82 rise && \
     conda install --name python2 --quiet --yes -c pdrops pygraphviz -y && \
-    /opt/conda/bin/pip2 install py2cytoscape pydot graphviz tqdm gseapy
+    /opt/conda/envs/python2/bin/pip install py2cytoscape pydot graphviz tqdm gseapy
 
 # Add idr-notebook library to path
 RUN echo /notebooks/library > /opt/conda/envs/python2/lib/python2.7/site-packages/idr-notebooks.pth

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,8 @@ RUN mkdir -p /home/jovyan/.local/share/jupyter/kernels/python2 && \
 #RUN usermod -l omero jovyan -m -d /home/omero
 #USER omero
 
-WORKDIR /notebooks
+# This will be updated and made read-only during startup
+RUN git clone https://github.com/IDR/idr-notebooks.git /notebooks
+ADD update-notebooks-and-start.sh /usr/local/bin/update-notebooks-and-start.sh
 
-# smoke test that it's importable at least
-RUN start-singleuser.sh -h > /dev/null
-CMD ["start-singleuser.sh"]
+CMD ["update-notebooks-and-start.sh"]

--- a/update-notebooks-and-start.sh
+++ b/update-notebooks-and-start.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -ex
+
+# Warning: scratch and shared volumes may be mounted under notebooks
+# and must remain writeable
+cd /notebooks
+find /notebooks -xdev -exec chmod u+w {} \;
+git fetch origin
+git reset --hard origin/master
+find /notebooks -xdev -exec chmod a-w {} \;
+
+exec /usr/local/bin/start-singleuser.sh "$@"


### PR DESCRIPTION
Adding a couple of python libraries to the docker file for the Gene Ontology notebooks.
Not sure if the best way is to update them here or have a requirements file in idr-py repository to manage the dependencies. Can close this PR if that sounds like a stable option.

@joshmoore @manics 