### PR TITLE
Don't exit if an error occurs whilst updating notebooks from github

### DIFF
--- a/update-notebooks-and-start.sh
+++ b/update-notebooks-and-start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+set -x
 
 # Warning: scratch and shared volumes may be mounted under notebooks
 # and must remain writeable


### PR DESCRIPTION
The notebook image should have already have a reasonably up-to-date version of the notebooks from when the Docker image was built. Should we therefore ignore GitHub errors when trying to update the notebooks?