### PR TITLE
Add and enable nbresuse for displaying memory usage, add idr-py to dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN conda install --name python2 --quiet --yes \
     matplotlib \
     pandas \
     pillow \
+    psutil \
     pytables \
     pytest \
     python-igraph \
@@ -44,6 +45,12 @@ RUN conda install --name python2 --quiet --yes -c bioconda zeroc-ice && \
         py2cytoscape \
         pydot \
         tqdm
+
+# Display resource usage in notebooks https://github.com/yuvipanda/nbresuse
+RUN pip install git+https://github.com/manics/nbresuse.git@8cb4f5d8879c573a4fe690c4f53c2b0a99d18d69 && \
+    jupyter serverextension enable --py nbresuse && \
+    jupyter nbextension install --py --user nbresuse && \
+    jupyter nbextension enable --py --user nbresuse
 
 # Add idr-notebook library to path
 RUN echo /notebooks/library > /opt/conda/envs/python2/lib/python2.7/site-packages/idr-notebooks.pth

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN /opt/conda/envs/python2/bin/pip install omego && \
 # scipy-notebook only includes python3 packages
 RUN conda install --name python2 --quiet --yes \
     bokeh \
+    ipywidgets \
     joblib \
     markdown \
     matplotlib \
@@ -29,10 +30,10 @@ RUN conda install --name python2 --quiet --yes \
     pytables \
     pytest \
     python-igraph \
-    seaborn \
     scikit-image \
     scikit-learn \
-    scipy
+    scipy \
+    seaborn
 
 # RISE: "Live" Reveal.js Jupyter/IPython Slideshow Extension
 # https://github.com/damianavila/RISE

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN conda install --name python2 --quiet --yes -c bioconda zeroc-ice && \
         py2cytoscape \
         pydot \
         tqdm \
-        git+https://github.com/IDR/idr-py@master
+        idr-py==0.1
 
 # Display resource usage in notebooks https://github.com/yuvipanda/nbresuse
 RUN pip install https://github.com/IDR/nbresuse/archive/0.1.0-idr.zip && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,8 @@ RUN conda install --name python2 --quiet --yes -c bioconda zeroc-ice && \
         gseapy \
         py2cytoscape \
         pydot \
-        tqdm
+        tqdm \
+        git+https://github.com/IDR/idr-py@master
 
 # Display resource usage in notebooks https://github.com/yuvipanda/nbresuse
 RUN pip install git+https://github.com/manics/nbresuse.git@8cb4f5d8879c573a4fe690c4f53c2b0a99d18d69 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN conda install --name python2 --quiet --yes -c bioconda zeroc-ice && \
         git+https://github.com/IDR/idr-py@master
 
 # Display resource usage in notebooks https://github.com/yuvipanda/nbresuse
-RUN pip install git+https://github.com/manics/nbresuse.git@8cb4f5d8879c573a4fe690c4f53c2b0a99d18d69 && \
+RUN pip install https://github.com/IDR/nbresuse/archive/0.1.0-idr.zip && \
     jupyter serverextension enable --py nbresuse && \
     jupyter nbextension install --py --user nbresuse && \
     jupyter nbextension enable --py --user nbresuse

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,9 +53,6 @@ RUN pip install git+https://github.com/manics/nbresuse.git@8cb4f5d8879c573a4fe69
     jupyter nbextension install --py --user nbresuse && \
     jupyter nbextension enable --py --user nbresuse
 
-# Add idr-notebook library to path
-RUN echo /notebooks/library > /opt/conda/envs/python2/lib/python2.7/site-packages/idr-notebooks.pth
-
 RUN mkdir -p /home/jovyan/.local/share/jupyter/kernels/python2 && \
     sed 's/Python 2/OMERO Python 2/' \
         /opt/conda/envs/python2/share/jupyter/kernels/python2/kernel.json > \

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,9 @@ RUN conda install --name python2 --quiet --yes \
 
 # RISE: "Live" Reveal.js Jupyter/IPython Slideshow Extension
 # https://github.com/damianavila/RISE
+RUN conda install --quiet --yes -c damianavila82 rise
+
 RUN conda install --name python2 --quiet --yes -c bioconda zeroc-ice && \
-    conda install --name python2 --quiet --yes -c damianavila82 rise && \
     conda install --name python2 --quiet --yes -c pdrops pygraphviz && \
     /opt/conda/envs/python2/bin/pip install \
         graphviz \


### PR DESCRIPTION
The memory usage should be shown in the bottom-right corner of the header when running a notebook.
<img width="976" alt="screen shot 2017-10-11 at 16 57 04" src="https://user-images.githubusercontent.com/1644105/31451893-4a87af5a-aea5-11e7-914a-b02bf43bdd6a.png">


This also includes the idr-py work from #14 to avoid merge conflicts