### PR TITLE
Edited Dockerfile to point to eleanorwilliams/idr-notebooks.git EMBLP…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN mkdir -p /home/jovyan/.local/share/jupyter/kernels/python2 && \
 #USER omero
 
 WORKDIR /notebooks
-RUN git clone -b EMBLPredoc2017Notebooks --single-branch https://github.com/eleanorwilliams/idr-notebooks.git EMBLPredoc2017Notebooks /notebooks
+RUN git clone -b EMBLPredoc2017Notebooks --single-branch https://github.com/eleanorwilliams/idr-notebooks.git /notebooks
 
 # Autodetects jupyterhub and standalone modes
 CMD ["start-notebook.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN mkdir -p /home/jovyan/.local/share/jupyter/kernels/python2 && \
 #USER omero
 
 WORKDIR /notebooks
-RUN git clone https://github.com/IDR/idr-notebooks.git /notebooks
+RUN git clone -b EMBLPredoc2017Notebooks --single-branch https://github.com/eleanorwilliams/idr-notebooks.git EMBLPredoc2017Notebooks /notebooks
 
 # Autodetects jupyterhub and standalone modes
 CMD ["start-notebook.sh"]


### PR DESCRIPTION
…redoc2017Notebooks branch

Please wait until the content of https://github.com/IDR/idr-notebooks/pull/46 is signed off.

This Dockerfile is for the idr-training/jupyter server. 

 

