### PR TITLE
Bump base-notebook to include jupyterlab 0.32 (+ hub extension)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,9 @@ RUN pip install git+https://github.com/data-8/gitautosync && \
 # create a python2 environment (for OMERO-PY compatibility)
 RUN mkdir .setup
 ADD environment-python2.yml .setup/
-RUN conda env create -n python2 -f .setup/environment-python2.yml
+RUN conda env create -n python2 -f .setup/environment-python2.yml && \
+    # Jupyterlab component for ipywidgets (must match jupyterlab version) \
+    jupyter labextension install @jupyter-widgets/jupyterlab-manager@^0.35
 
 # Autodetects jupyterhub and standalone modes
 CMD ["start-notebook.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,13 +12,6 @@ RUN apt-get update -y && \
 USER jovyan
 # Default workdir: /home/jovyan
 
-# Display resource usage in notebooks https://github.com/yuvipanda/nbresuse
-# TODO: Consider removing, doesn't work with JupyterLab
-RUN pip install https://github.com/IDR/nbresuse/archive/0.1.0-idr.zip && \
-    jupyter serverextension enable --py nbresuse && \
-    jupyter nbextension install --py --user nbresuse && \
-    jupyter nbextension enable --py --user nbresuse
-
 # Autoupdate notebooks https://github.com/data-8/nbgitpuller
 RUN pip install git+https://github.com/data-8/gitautosync && \
     jupyter serverextension enable --py nbgitpuller

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM jupyter/base-notebook:8a1b90cbcba5
-# jupyter/base-notebook updated 2018-04-09
+FROM jupyter/base-notebook:1dc1481636a2
+# jupyter/base-notebook updated 2018-04-27
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 USER root
@@ -22,9 +22,6 @@ RUN pip install https://github.com/IDR/nbresuse/archive/0.1.0-idr.zip && \
 # Autoupdate notebooks https://github.com/data-8/nbgitpuller
 RUN pip install git+https://github.com/data-8/gitautosync && \
     jupyter serverextension enable --py nbgitpuller
-
-# JupyterHub JupyterLab integration
-RUN jupyter labextension install @jupyterlab/hub-extension
 
 # create a python2 environment (for OMERO-PY compatibility)
 RUN mkdir .setup


### PR DESCRIPTION
Incorporate changes from https://github.com/jupyter/docker-stacks/commit/a5d350fb0f4e61f6e14f612bac324b7680efaffa