### PR TITLE
Update to latest base image (jupyterlab 0.33)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir .setup
 ADD environment-python2.yml .setup/
 RUN conda env create -n python2 -f .setup/environment-python2.yml && \
     # Jupyterlab component for ipywidgets (must match jupyterlab version) \
-    jupyter labextension install @jupyter-widgets/jupyterlab-manager@^0.35
+    jupyter labextension install @jupyter-widgets/jupyterlab-manager@^0.36
 
 # Autodetects jupyterhub and standalone modes
 CMD ["start-notebook.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM jupyter/base-notebook:1dc1481636a2
-# jupyter/base-notebook updated 2018-04-27
+FROM jupyter/base-notebook:45e010d9e849
+# jupyter/base-notebook updated 2018-07-31
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 USER root


### PR DESCRIPTION
This should include the link-to-notebook fix:
- https://github.com/jupyterlab/jupyterlab/issues/4786
- https://github.com/jupyterlab/jupyterlab/pull/4708