### PR TITLE
Bump image and nbval again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM jupyter/base-notebook:5b2160dfd919
-# jupyter/base-notebook updated 2018-11-16
+FROM jupyter/base-notebook:87210526f381
+# jupyter/base-notebook updated 2010-01-08
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,10 @@ USER jovyan
 # Default workdir: /home/jovyan
 
 # Autoupdate notebooks https://github.com/data-8/nbgitpuller
+# nbval for testing reproducibility
 RUN pip install git+https://github.com/data-8/gitautosync && \
-    jupyter serverextension enable --py nbgitpuller
+    jupyter serverextension enable --py nbgitpuller && \
+    conda install -y -q nbval
 
 # create a python2 environment (for OMERO-PY compatibility)
 RUN mkdir .setup

--- a/environment-python2.yml
+++ b/environment-python2.yml
@@ -8,7 +8,6 @@ dependencies:
 # conda-forge
 - ipywidgets=7.4.*
 - matplotlib=2.2.*
-- nbval=0.9.*
 - pandas=0.23.*
 - pillow=5.*
 - pytables=3.4.*


### PR DESCRIPTION
Main change is to put `nbval` in the base environment so it can see all kernels instead of just Python2